### PR TITLE
Look for non localized app name

### DIFF
--- a/Sources/IACCore/Extensions.swift
+++ b/Sources/IACCore/Extensions.swift
@@ -42,7 +42,7 @@ func appName() -> String {
     else if let appName = Bundle.main.infoDictionary?["CFBundleName"] as? String {
         return appName
     }
-    return Bundle.main.infoDictionary?["CFBundleDisplayName"] as? String ?? "IAC"
+    return "IAC"
 }
 
 func open(_ url: URL) {

--- a/Sources/IACCore/Extensions.swift
+++ b/Sources/IACCore/Extensions.swift
@@ -36,6 +36,12 @@ func appName() -> String {
     if let appName = Bundle.main.localizedInfoDictionary?["CFBundleDisplayName"] as? String {
         return appName
     }
+    else if let appName = Bundle.main.infoDictionary?["CFBundleDisplayName"] as? String {
+        return appName
+    }
+    else if let appName = Bundle.main.infoDictionary?["CFBundleName"] as? String {
+        return appName
+    }
     return Bundle.main.infoDictionary?["CFBundleDisplayName"] as? String ?? "IAC"
 }
 


### PR DESCRIPTION
Not all apps localize their app name. Look for CFBundleDisplayName in the main dictionary and fallback to CFBundleName if not found.