### PR TITLE
macOS target >=10.15

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "Inter-AppCommunication",
-    platforms: [.iOS(.v13), .macOS(.v10_13), .tvOS(.v13)],
+    platforms: [.iOS(.v13), .macOS(.v10_15), .tvOS(.v13)],
     products: [
         .library(name: "IACCore", targets: ["IACCore"]),
         .library(name: "IACClients", targets: ["IACClients"]),


### PR DESCRIPTION
The method `withCheckedThrowingContinuation` is only available on macOS 10.15 or later.